### PR TITLE
Do not pass `watch` option to webpack to avoid depreciation warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,7 @@ module.exports = function (options, wp, done) {
 
   options = clone(options) || {};
   var config = options.config || options;
+  delete config.watch;
 
   // Webpack 4 doesn't support the `quiet` attribute, however supports
   // setting `stats` to a string within an array of configurations

--- a/index.js
+++ b/index.js
@@ -104,7 +104,6 @@ module.exports = function (options, wp, done) {
     var self = this;
     var handleConfig = function (config) {
       config.output = config.output || {};
-      config.watch = !!options.watch;
 
       // Determine pipe'd in entry
       if (Object.keys(entries).length > 0) {
@@ -120,7 +119,6 @@ module.exports = function (options, wp, done) {
       config.entry = config.entry || entry;
       config.output.path = config.output.path || process.cwd();
       config.output.filename = config.output.filename || '[hash].js';
-      config.watch = options.watch;
       entry = [];
 
       if (!config.entry || config.entry.length < 1) {


### PR DESCRIPTION
Fixes https://github.com/shama/webpack-stream/issues/230